### PR TITLE
feat: add WordPress media upload tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # WordPress MCP Server
 
-A Model Context Protocol (MCP) server for managing WordPress sites via the REST API. This server provides 18 tools for comprehensive WordPress management including posts, users, media, categories, tags, and site settings.
+A Model Context Protocol (MCP) server for managing WordPress sites via the REST API. This server provides 21 tools for comprehensive WordPress management including posts, users, media, categories, tags, and site settings.
 
 ## Features
 
-### Posts Management (6 tools)
+### Posts Management (5 tools)
 - **list_posts**: List posts with filtering options (status, date, author, categories, tags)
 - **retrieve_post**: Get detailed information about a specific post
 - **create_post**: Create new posts with full metadata support
@@ -16,9 +16,10 @@ A Model Context Protocol (MCP) server for managing WordPress sites via the REST 
 - **get_me**: Get current user information and capabilities
 - **validate_credential**: Test WordPress authentication
 
-### Media Management (3 tools)
+### Media Management (4 tools)
 - **list_media**: List media files with filtering options
-- **update_media**: Update media metadata (title, slug, author)
+- **upload_media**: Upload local media files with title, alt text, caption, description, and post attachment metadata
+- **update_media**: Update media metadata (title, slug, author, alt text, caption, description, post attachment)
 - **delete_media**: Delete media files
 
 ### Categories Management (4 tools)

--- a/src/tools/media.py
+++ b/src/tools/media.py
@@ -1,5 +1,7 @@
 """WordPress Media management tools."""
 
+import mimetypes
+from pathlib import Path
 from typing import Optional, Union, Dict, Any, Annotated, Literal
 from urllib.parse import quote
 
@@ -16,11 +18,42 @@ def _format_media_response(response_json: Union[dict, list]) -> Union[dict, list
             keys = [
                 "id", "date", "date_gmt", "modified", "modified_gmt",
                 "slug", "status", "type", "link", "title", "author",
-                "media_type", "mime_type"
+                "media_type", "mime_type", "source_url", "alt_text",
+                "caption", "description"
             ]
             return {key: response_json[key] for key in keys if key in response_json}
     except Exception:
         return response_json
+
+
+def _build_media_metadata(
+    title: Optional[str] = None,
+    alt_text: Optional[str] = None,
+    caption: Optional[str] = None,
+    description: Optional[str] = None,
+    slug: Optional[str] = None,
+    author_id: Optional[int] = None,
+    post_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build a WordPress media metadata payload from optional fields."""
+    media_data: Dict[str, Any] = {}
+
+    if title is not None:
+        media_data["title"] = title
+    if alt_text is not None:
+        media_data["alt_text"] = alt_text
+    if caption is not None:
+        media_data["caption"] = caption
+    if description is not None:
+        media_data["description"] = description
+    if slug is not None:
+        media_data["slug"] = slug
+    if author_id is not None:
+        media_data["author"] = author_id
+    if post_id is not None:
+        media_data["post"] = post_id
+
+    return media_data
 
 
 @mcp.tool
@@ -106,25 +139,83 @@ def list_media(
 
 
 @mcp.tool
+def upload_media(
+    file_path: Annotated[str, "Local path of the media file to upload"],
+    title: Annotated[Optional[str], "Title for the media file - default: None"] = None,
+    alt_text: Annotated[Optional[str], "Alternative text for images - default: None"] = None,
+    caption: Annotated[Optional[str], "Caption for the media file - default: None"] = None,
+    description: Annotated[Optional[str], "Description for the media file - default: None"] = None,
+    slug: Annotated[Optional[str], "Slug for the media file - default: None"] = None,
+    author_id: Annotated[Optional[int], "Author ID for the media file - default: None"] = None,
+    post_id: Annotated[Optional[int], "Post ID to attach the media file to - default: None"] = None,
+) -> Dict[str, Any]:
+    """Upload a local media file to the WordPress media library.
+
+    This sends a multipart upload to the WordPress REST API and can attach
+    editor-facing metadata such as image alt text, caption, and description.
+    """
+    path = Path(file_path).expanduser()
+
+    if not path.exists():
+        raise ValueError(f"Media file does not exist: {file_path}")
+    if not path.is_file():
+        raise ValueError(f"Media path is not a file: {file_path}")
+
+    media_data = _build_media_metadata(
+        title=title,
+        alt_text=alt_text,
+        caption=caption,
+        description=description,
+        slug=slug,
+        author_id=author_id,
+        post_id=post_id,
+    )
+    mime_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+
+    session = config.create_session()
+    session.headers.pop("Content-Type", None)
+
+    with path.open("rb") as file_handle:
+        response = session.post(
+            f"{config.api_url}/media",
+            files={"file": (path.name, file_handle, mime_type)},
+            data=media_data,
+        )
+
+    if response.status_code == 201:
+        return _format_media_response(response.json())
+    elif response.status_code == 401:
+        raise Exception(f"Authentication failed: {response.text}")
+    elif response.status_code == 403:
+        raise Exception(f"Permission denied: {response.text}")
+    else:
+        raise Exception(f"Failed to upload media: {response.status_code} - {response.text}")
+
+
+@mcp.tool
 def update_media(
     media_id: Annotated[int, "The ID of the media file"],
     title: Annotated[Optional[str], "New title for the media file - default: None"] = None,
     slug: Annotated[Optional[str], "New slug for the media file - default: None"] = None,
-    author_id: Annotated[Optional[int], "New author ID for the media file - default: None"] = None
+    author_id: Annotated[Optional[int], "New author ID for the media file - default: None"] = None,
+    alt_text: Annotated[Optional[str], "New alternative text for images - default: None"] = None,
+    caption: Annotated[Optional[str], "New caption for the media file - default: None"] = None,
+    description: Annotated[Optional[str], "New description for the media file - default: None"] = None,
+    post_id: Annotated[Optional[int], "New post ID to attach the media file to - default: None"] = None,
 ) -> Dict[str, Any]:
     """Update the metadata of a media file in WordPress site.
     
     At least one field must be provided to update.
     """
-    # Build update data (only include provided fields)
-    media_data = {}
-    
-    if title is not None:
-        media_data["title"] = title
-    if slug is not None:
-        media_data["slug"] = slug
-    if author_id is not None:
-        media_data["author"] = author_id
+    media_data = _build_media_metadata(
+        title=title,
+        alt_text=alt_text,
+        caption=caption,
+        description=description,
+        slug=slug,
+        author_id=author_id,
+        post_id=post_id,
+    )
     
     if not media_data:
         raise ValueError("At least one field must be provided to update")

--- a/tests/test_fastmcp_smoke.py
+++ b/tests/test_fastmcp_smoke.py
@@ -2,7 +2,10 @@
 
 import inspect
 import os
+import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 from fastmcp import Client
 
@@ -26,6 +29,7 @@ EXPECTED_TOOL_NAMES = {
     "get_me",
     "validate_credential",
     "list_media",
+    "upload_media",
     "update_media",
     "delete_media",
     "list_categories",
@@ -56,3 +60,54 @@ class FastMCPSmokeTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIn("title", tools_by_name["create_post"].inputSchema["properties"])
         self.assertIn("post_id", tools_by_name["delete_post"].inputSchema["properties"])
+        self.assertIn("file_path", tools_by_name["upload_media"].inputSchema["properties"])
+
+
+class MediaUploadTest(unittest.TestCase):
+    def test_upload_media_posts_multipart_file_and_metadata(self):
+        response = Mock()
+        response.status_code = 201
+        response.json.return_value = {
+            "id": 123,
+            "title": {"rendered": "Hero image"},
+            "alt_text": "Alt text",
+            "caption": {"rendered": "Caption"},
+            "description": {"rendered": "Description"},
+            "source_url": "https://example.com/wp-content/uploads/hero.jpg",
+            "mime_type": "image/jpeg",
+        }
+
+        session = Mock()
+        session.headers = {"Content-Type": "application/json"}
+        session.post.return_value = response
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            image_path = Path(tmp_dir) / "hero.jpg"
+            image_path.write_bytes(b"fake image")
+
+            with patch.object(media.config, "create_session", return_value=session):
+                result = media.upload_media(
+                    str(image_path),
+                    title="Hero image",
+                    alt_text="Alt text",
+                    caption="Caption",
+                    description="Description",
+                    post_id=42,
+                )
+
+        self.assertNotIn("Content-Type", session.headers)
+        session.post.assert_called_once()
+        _, kwargs = session.post.call_args
+        self.assertEqual(kwargs["data"]["title"], "Hero image")
+        self.assertEqual(kwargs["data"]["alt_text"], "Alt text")
+        self.assertEqual(kwargs["data"]["caption"], "Caption")
+        self.assertEqual(kwargs["data"]["description"], "Description")
+        self.assertEqual(kwargs["data"]["post"], 42)
+        self.assertEqual(kwargs["files"]["file"][0], "hero.jpg")
+        self.assertEqual(kwargs["files"]["file"][2], "image/jpeg")
+        self.assertEqual(result["id"], 123)
+        self.assertEqual(result["alt_text"], "Alt text")
+
+    def test_upload_media_rejects_missing_file(self):
+        with self.assertRaisesRegex(ValueError, "Media file does not exist"):
+            media.upload_media("/tmp/does-not-exist.jpg")


### PR DESCRIPTION
## Summary

Adds an `upload_media` tool for the WordPress media library.

The new tool uploads a local file via the WordPress REST API `/media` endpoint and supports the editor-facing metadata that usually needs to travel with an image:

- title
- alt text
- caption
- description
- slug
- author ID
- attached post ID

This also expands `update_media` so the same metadata can be edited after upload.

## Why

The server already supports listing, updating, and deleting media, but there was no way to add a new media item. That leaves a gap for publishing workflows where an agent prepares an article, chooses or generates an image, and then needs to place that image in the WordPress media library before using it in a post.

One implementation detail: the shared session sets `Content-Type: application/json`, which is correct for JSON endpoints but prevents `requests` from generating a multipart boundary for file uploads. `upload_media` removes that header for the upload request so `requests` can send proper multipart form data.

## Validation

- `python3.11 -m venv .venv`
- `.venv/bin/python -m pip install -e .`
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m compileall src tests`
